### PR TITLE
FLUID-5367: Removed "src" from links to demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                             <h2>Preferences Framework</h2>
                             <p>Learner Options Personalize interfaces and content to meet individual needs and preferences.</p>
                             <div class="flbuild-blocklinks col-sm-9">
-                                <div class="flbuild-blocklink"><a href="http://build.fluidproject.org/infusion/src/demos/prefsFramework/">interface options demo</a></div>
+                                <div class="flbuild-blocklink"><a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">interface options demo</a></div>
                                 <div class="flbuild-blocklink"><a href="http://build.fluidproject.org/explorationTool">preference exploration tool demo</a></div>
                             </div>
                         </div>
@@ -84,35 +84,35 @@
                 <div class="flbuild-right col-lg-6">
                     <div class="flbuild-box">
                         <h2>Infusion JS Framework</h2>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/renderer/">Renderer</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/renderer/">Renderer</a></h3>
                         <p>Allows you to create user interface templates in pure
     HTML and render the pages entirely on the client side. It
     offers a clean separation of Model and View, working with
     internal Renderer Component Trees that are independent
     of the mark-up.</p>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/keyboard-a11y/">Keyboard Accessibility Plugin</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/keyboard-a11y/">Keyboard Accessibility Plugin</a></h3>
                         <p>The jQuery Keyboard Accessibility Plugin makes it easy for
     developers to add keyboard handlers to their code
     without a lot of extra overhead.</p>
                     </div>
                     <div class="flbuild-box">
                         <h2>Infusion Components</h2>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/reorderer/imageReorderer/">Reorderer</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/reorderer/imageReorderer/">Reorderer</a></h3>
                         <p>Provides drag and drop customization of modules in a
     portal environment.</p>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/inlineEdit/simple/">Inline Edit</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/inlineEdit/simple/">Inline Edit</a></h3>
                         <p>Allows a user to do quick edits to simple text without
     having to switch modes or screens. All work is done on the
     same interface which helps the user maintain context.</p>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/pager/">Pager</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/pager/">Pager</a></h3>
                         <p>Allows users to break up long lists of items into separate
     pages. They may decide whether or not they want paging,
     and how many results are displayed per page.</p>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/uploader/">Uploader</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/uploader/">Uploader</a></h3>
                         <p>Allows users to upload files. The user can select desired
     files from their computer, view them in a queue, add or
     remove files to and from the queue, and upload them. </p>
-                        <h3><a href="http://build.fluidproject.org/infusion/src/demos/progress/">Progress</a></h3>
+                        <h3><a href="http://build.fluidproject.org/infusion/demos/progress/">Progress</a></h3>
                         <p>Provides a usable and accessible linear progress display
     for use on its own or with other Fluid components.</p>
                     </div>


### PR DESCRIPTION
Now that the built zip is being deployed, we no longer need the "src" in the path to the demos.

http://issues.fluidproject.org/browse/FLUID-5367
