### PR TITLE
NOJIRA: add links to SJRK storytelling tool demo and tests.

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,17 @@
                             <li><a href="http://build.fluidproject.org/chartAuthoring/demos">Chart authoring demo</a></li>
                         </ul>
 
+                        <h3>Social Justice Repair Kit</h3>
+                        <ul>
+                            <li><a href="http://build.fluidproject.org/sjrk-storyTelling/">Storytelling tool demo</a>
+                            <ul>
+                                <li>
+                                    <a href="http://build.fluidproject.org/sjrk-storyTelling/tests/all-tests.html">Storytelling tool tests</a>        
+                                </li>
+                            </ul>
+                            </li>
+                        </ul>
+
                         <h3>Preferences framework</h3>
                         <ul>
                             <li><a href="http://build.fluidproject.org/infusion/demos/prefsFramework/">Preferences framework demo - "Climate Change"</a></li>


### PR DESCRIPTION
Adds links to the SJRK storytelling tool (currently building from https://github.com/waharnum/sjrk-storyTelling/tree/deployment).

@michelled, do you have time to review this quickly?