### PR TITLE
Add analytics tracking code

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,19 @@
         <!-- Scripts -->
         <link rel="icon" type="image/png" href="./images/favicon.png">
         <script type="text/javascript" src="lib/infusion/infusion-custom.js"></script>
+        <script type="text/javascript">
+          var _paq = window._paq || [];
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="https://analytics.inclusivedesign.ca/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '15']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+        </script>
 
         <title>Builds | Fluid</title>
     </head>


### PR DESCRIPTION
The IDRC has an instance of [Matomo](https://matomo.org) running to replace all usage of Google Analytics and other tracking services that could cause some concerns about data privacy. It's a self-hosted instance and no data is shared with any other company. It's available at https://analytics.inclusivedesign.ca

Recently in the fluid-work mailing list, a question was made about who is using the Build website and how. The intent of this PR is to add the Matomo tracking code so that question can be answered.

For members of the Fluid Project, access can be requested in the #fluid-work IRC channel or through the fluid-work mailing list.