### PR TITLE
feat: update links to point to build-infusion.fluidproject.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,6 @@
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/slidingPanel/html/SlidingPanel-test.html">Sliding panel test</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/switch/html/Switch-test.html">Switch test</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tableOfContents/html/TableOfContents-test.html">Table of contents test</a></li>
-                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tabs/html/Tabs-test.html">Tabs test</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/textToSpeech/html/TextToSpeech-test.html">Text to speech test</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/textfieldControl/all-tests.html">Textfield Control: all tests</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tooltip/html/Tooltip-test.html">Tooltip test</a></li>

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
 
                         <h3>Preferences framework</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/prefsFramework/">Preferences framework demo - "Climate Change"</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/prefsFramework/">Preferences framework demo - "Climate Change"</a></li>
                             <li><a href="https://build.fluidproject.org/prefsEditors/demos/explorationTool/">Preferences exploration tool demo - "Electrons"</a></li>
                             <li>
                                 <h4>First Discovery Tool Demos</h4>
@@ -136,29 +136,29 @@
 
                         <h3>Infusion JS Framework</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/renderer/">Renderer demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/keyboard-a11y/">Keyboard Accessibility Plugin demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/renderer/">Renderer demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/keyboard-a11y/">Keyboard Accessibility Plugin demo</a></li>
                         </ul>
 
                         <h3>Infusion Components</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/inlineEdit/">Inline edit demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/overviewPanel/">Overview panel demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/pager/">Pager demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/progress/">Progress demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/inlineEdit/">Inline edit demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/overviewPanel/">Overview panel demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/pager/">Pager demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/progress/">Progress demo</a></li>
                             <li> Reorderer
                                 <ul>
-                                    <li><a href="https://build.fluidproject.org/infusion/demos/reorderer/gridReorderer/">Grid reorderer demo</a></li>
-                                    <li><a href="https://build.fluidproject.org/infusion/demos/reorderer/imageReorderer/">Image reorderer demo</a></li>
-                                    <li><a href="https://build.fluidproject.org/infusion/demos/reorderer/layoutReorderer/">Layout reorderer demo</a></li>
-                                    <li><a href="https://build.fluidproject.org/infusion/demos/reorderer/listReorderer/">List reorderer demo</a></li>
+                                    <li><a href="https://build-infusion.fluidproject.org/demos/reorderer/gridReorderer/">Grid reorderer demo</a></li>
+                                    <li><a href="https://build-infusion.fluidproject.org/demos/reorderer/imageReorderer/">Image reorderer demo</a></li>
+                                    <li><a href="https://build-infusion.fluidproject.org/demos/reorderer/layoutReorderer/">Layout reorderer demo</a></li>
+                                    <li><a href="https://build-infusion.fluidproject.org/demos/reorderer/listReorderer/">List reorderer demo</a></li>
                                 </ul>
                             </li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/switch/">Switch demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/tableOfContents/">Table of contents demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/textfieldControl/">Textfield Control demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/uiOptions/">UI options demo</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/demos/uploader/">Uploader demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/switch/">Switch demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/tableOfContents/">Table of contents demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/textfieldControl/">Textfield Control demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/uiOptions/">UI options demo</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/demos/uploader/">Uploader demo</a></li>
                         </ul>
                     </section>
 
@@ -168,28 +168,28 @@
 
                         <h3>Preferences framework</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/preferences/conditionalAdjusters/">Conditional adjusters</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/preferences/conditionalAdjusters-singlePanel/">Conditional Adjusters - single panel</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/preferences/minimalEditor/">Minimal editor</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/preferences/minimalFootprint/">Minimal footprint</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/preferences/usingGrades/">Using grades</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/preferences/conditionalAdjusters/">Conditional adjusters</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/preferences/conditionalAdjusters-singlePanel/">Conditional Adjusters - single panel</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/preferences/minimalEditor/">Minimal editor</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/preferences/minimalFootprint/">Minimal footprint</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/preferences/usingGrades/">Using grades</a></li>
                         </ul>
 
                         <h3>Infusion JS Framework</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/renderer/dataBinding/">Renderer: Data binding</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/renderer/programmaticTree/">Renderer: Programmatic tree</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/framework/renderer/selectors/">Renderer: Selectors</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/renderer/dataBinding/">Renderer: Data binding</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/renderer/programmaticTree/">Renderer: Programmatic tree</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/framework/renderer/selectors/">Renderer: Selectors</a></li>
                         </ul>
 
                         <h3>Infusion Components</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/pager/annotateSortedColumn/">Pager: Annotated sorted column</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/pager/initialPageIndex/">Pager: Initial page index</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/pager/markupDriven/">Pager: Markup driven</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/progress/bidirectionalAnimation/">Progress: Bidirectional animation</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/progress/noAnimation/">Progress: No animation</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/examples/components/reorderer/tableRow/">Reorderer: Table rows</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/pager/annotateSortedColumn/">Pager: Annotated sorted column</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/pager/initialPageIndex/">Pager: Initial page index</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/pager/markupDriven/">Pager: Markup driven</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/progress/bidirectionalAnimation/">Progress: Bidirectional animation</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/progress/noAnimation/">Progress: No animation</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/examples/components/reorderer/tableRow/">Reorderer: Table rows</a></li>
                         </ul>
                     </section>
 
@@ -205,52 +205,52 @@
 
                         <h3>All Infusion tests</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/all-tests.html">Run all automated tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/all-tests.html">Run all automated tests</a></li>
                         </ul>
 
                         <h3>Infusion Framework Tests</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/framework-tests/core/all-tests.html">Core: all tests</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/framework-tests/enhancement/html/ContextAwareness-test.html">Context Awareness test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/framework-tests/preferences/all-tests.html">Preferences: all tests</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/framework-tests/renderer/html/Renderer-test.html">Renderer test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/framework-tests/renderer/html/RendererUtilities-test.html">Renderer utilities test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/test-core/testTests/html/ConditionalTestUtils-test.html">Testing: Conditional Test Utils test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/test-core/testTests/html/IoCTesting-test.html">Testing: IoC Testing Framework test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/test-core/testTests/html/IoCTestingView-test.html">Testing: IoC View Testing Framework test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/test-core/testTests/html/jqUnit-test.html">Testing: jqUnit test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/framework-tests/core/all-tests.html">Core: all tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/framework-tests/enhancement/html/ContextAwareness-test.html">Context Awareness test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/framework-tests/preferences/all-tests.html">Preferences: all tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/framework-tests/renderer/html/Renderer-test.html">Renderer test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/framework-tests/renderer/html/RendererUtilities-test.html">Renderer utilities test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/test-core/testTests/html/ConditionalTestUtils-test.html">Testing: Conditional Test Utils test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/test-core/testTests/html/IoCTesting-test.html">Testing: IoC Testing Framework test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/test-core/testTests/html/IoCTestingView-test.html">Testing: IoC View Testing Framework test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/test-core/testTests/html/jqUnit-test.html">Testing: jqUnit test</a></li>
                         </ul>
 
                         <h3>Infusion Component Tests</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/inlineEdit/html/InlineEdit-test.html">Inline edit test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/overviewPanel/html/OverviewPanel-test.html">Overview panel test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/pager/html/PagedTable-test.html">Paged table test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/pager/html/Pager-test.html">Pager test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/progress/html/Progress-test.html">Progress test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/reorderer/all-tests.html">Reorderer: all tests</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/slidingPanel/html/SlidingPanel-test.html">Sliding panel test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/switch/html/Switch-test.html">Switch test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/tableOfContents/html/TableOfContents-test.html">Table of contents test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/tabs/html/Tabs-test.html">Tabs test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/textToSpeech/html/TextToSpeech-test.html">Text to speech test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/textfieldControl/all-tests.html">Textfield Control: all tests</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/tooltip/html/Tooltip-test.html">Tooltip test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/uiOptions/html/UIOptions-test.html">UI options test</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/component-tests/uploader/all-tests.html">Uploader: all tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/inlineEdit/html/InlineEdit-test.html">Inline edit test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/overviewPanel/html/OverviewPanel-test.html">Overview panel test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/pager/html/PagedTable-test.html">Paged table test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/pager/html/Pager-test.html">Pager test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/progress/html/Progress-test.html">Progress test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/reorderer/all-tests.html">Reorderer: all tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/slidingPanel/html/SlidingPanel-test.html">Sliding panel test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/switch/html/Switch-test.html">Switch test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tableOfContents/html/TableOfContents-test.html">Table of contents test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tabs/html/Tabs-test.html">Tabs test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/textToSpeech/html/TextToSpeech-test.html">Text to speech test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/textfieldControl/all-tests.html">Textfield Control: all tests</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/tooltip/html/Tooltip-test.html">Tooltip test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/uiOptions/html/UIOptions-test.html">UI options test</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/component-tests/uploader/all-tests.html">Uploader: all tests</a></li>
                         </ul>
 
                         <h3>Infusion Manual Tests</h3>
                         <ul>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/components/inlineEdit/dropdown/">Inline edit: drop-down</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/components/inlineEdit/rich/">Inline edit: rich Text</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/core/multipleVersions/">Multiple versions of Infusion</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/core/performance-fastInvokers/">Performance: fast invokers</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/core/performance-get/">Performance: fluid.get</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/preferences/assortedContent/">Preferences editor: assorted content</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/preferences/fullPage/">Preferences editor: full page</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/framework/preferences/fullPage-schema/">Preferences editor: full page schemas</a></li>
-                            <li><a href="https://build.fluidproject.org/infusion/tests/manual-tests/components/reorderer/dynamic/">Reorderer: dynamic</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/components/inlineEdit/dropdown/">Inline edit: drop-down</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/components/inlineEdit/rich/">Inline edit: rich Text</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/core/multipleVersions/">Multiple versions of Infusion</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/core/performance-fastInvokers/">Performance: fast invokers</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/core/performance-get/">Performance: fluid.get</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/assortedContent/">Preferences editor: assorted content</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/fullPage/">Preferences editor: full page</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/fullPage-schema/">Preferences editor: full page schemas</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/components/reorderer/dynamic/">Reorderer: dynamic</a></li>
                         </ul>
                     </section>
                 </div>


### PR DESCRIPTION
Now that Infusion builds automatically via Netlify, this PR updates the links to Infusion components, demos, and tests to point to https://build-infusion.fluidproject.org instead of https://build.fluidproject.org/infusion.