### PR TITLE
feat: add redirects to capture requests to old URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,5 @@
+/chartAuthoring/*       https://build-chartauthoring.fluidproject.org/:splat
+/first-discovery/*      https://build-firstdiscovery.fluidproject.org/:splat
+/infusion/*             https://build-infusion.fluidproject.org/:splat
+/sjrk-storyTelling/*    https://staging-stories.floeproject.org/:splat
+/videoPlayer/*          https://build-videoplayer.fluidproject.org/:splat


### PR DESCRIPTION
I noticed a link to the Infusion build from fluidproject.org was broken because it was requesting the old URL. This PR adds splat redirects for all the old build paths to the new build sites.