### PR TITLE
FLUID-6782: add link to custom properties manual test

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,6 +231,7 @@
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/core/performance-fastInvokers/">Performance: fast invokers</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/core/performance-get/">Performance: fluid.get</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/assortedContent/">Preferences editor: assorted content</a></li>
+                            <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/baseStyles/">Preferences editor: custom properties (base styles)</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/fullPage/">Preferences editor: full page</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/framework/preferences/fullPage-schema/">Preferences editor: full page schemas</a></li>
                             <li><a href="https://build-infusion.fluidproject.org/tests/manual-tests/components/reorderer/dynamic/">Reorderer: dynamic</a></li>


### PR DESCRIPTION
- Adds link to the UIO Css Custom Properties (Base styles) manual test

Requires: https://github.com/fluid-project/infusion/pull/1110